### PR TITLE
Update chat_models.ts for using newer model by default

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -631,9 +631,9 @@ export class ChatAnthropicMessages<
 
   maxTokens = 2048;
 
-  modelName = "claude-2.1";
+  modelName = "claude-3-7-sonnet-20250219";
 
-  model = "claude-2.1";
+  model = "claude-3-7-sonnet-20250219";
 
   invocationKwargs?: Kwargs;
 


### PR DESCRIPTION
Update default model for ChatAnthropic

## Description
This PR updates the default model in the ChatAnthropic class from `claude-2.1` to the latest supported model (`claude-3-sonnet-20240229`). The current default model is deprecated and will reach end-of-life on July 21st, 2025, causing errors for users who don't explicitly specify a model.

## Motivation
When users create a ChatAnthropic instance without specifying a model, they currently get the following error:

```
✘ [ERROR] The model 'claude-2.1' is deprecated and will reach end-of-life on July 21st, 2025. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.
Copy
This change ensures users get a supported model by default, improving the out-of-box experience with Anthropic's API.
```

## Changes
- Update the default model in the ChatAnthropic class from `claude-2.1` to `claude-3-sonnet-20240229`